### PR TITLE
Force sURL to string in getVideoIDFromURL() to fix errors when there is no video URL (yet)

### DIFF
--- a/jQuery.tubeplayer.js
+++ b/jQuery.tubeplayer.js
@@ -592,6 +592,8 @@
 	// fmt: youtube.com/watch?x=[anything]&v=[desired-token]&
 	TubePlayer.getVideoIDFromURL = function(sURL){
 		
+		sURL = sURL || ""; // make sure it's a string; sometimes the YT player API returns undefined, and then indexOf() below will fail
+		
 		var qryParamsStart = sURL.indexOf("?");
 		
 		var qryParams = sURL.substring(qryParamsStart, sURL.length);


### PR DESCRIPTION
Calling `$player.tubeplayer("data")` will fail if done very early on after video playback started (e.g. in an `onPlayerUnstarted` callback) because the YT player API returns `undefined` for the video URL at that point in time (it'll work fine shortly thereafter), which will cause `TubePlayer.getVideoIDFromURL()` to break when invoking `indexOf()` on what it believes to be a string.

This change simply forces an empty string when necessary, so the parsing will not error out. It won't succeed either of course, and return an empty string (IMO the function should return `null` rather than an empty string in such cases), but at least then `$player.tubeplayer("data")` will return something instead of failing.
