### PR TITLE
Set modestbranding default to false to conform with YouTube Branding Policies.

### DIFF
--- a/src/tubeplayer.js
+++ b/src/tubeplayer.js
@@ -153,7 +153,7 @@
         loop: 0,
         color: 'red', // 'red' or 'white'
         showinfo: false,
-        modestbranding: true,
+        modestbranding: false,
         protocol: window.location.protocol == "https:" ? "https" : "http", // set to 'https' for compatibility on SSL-enabled pages
         allowScriptAccess: "always",
         playerID: "tubeplayer-player-container",


### PR DESCRIPTION
Youtube branding policies require the Youtube logo to be displayed on the video player (modestbranding = false)

This PR brings this library up to conform with the YouTube API/Branding Policies which can be found here: https://developers.google.com/youtube/terms/developer-policies#f.-user-experience